### PR TITLE
Fix missing W in scss

### DIFF
--- a/alphabet-filter/src/alphabet-filter.scss
+++ b/alphabet-filter/src/alphabet-filter.scss
@@ -148,7 +148,7 @@
           }
         }
 
-        @each $item in ('a','b','c','d','e','f','g','h','i','j','k','l','m','o','p','q','r','s','t','u','v','x','y','z') {
+        @each $item in ('a','b','c','d','e','f','g','h','i','j','k','l','m','o','p','q','r','s','t','u','v','w','x','y','z') {
           .let-#{$item} ~ .let-#{$item} {
             > span { display: none; }
           }


### PR DESCRIPTION
Hey, Great package. Just noticed that every entry under 'w' got it's own divider heading. I have just added the 'w' into the css loop that you had going on :)